### PR TITLE
Fixed a typo/reference error

### DIFF
--- a/notebooks/Anomaly_Detection.ipynb
+++ b/notebooks/Anomaly_Detection.ipynb
@@ -280,7 +280,7 @@
     }
    ],
    "source": [
-    "# Create a Pandas dataframe from the Bro DNS log\n",
+    "# Create a Pandas dataframe from the Bro HTTP log\n",
     "bro_df = log_to_dataframe.LogToDataFrame('../data/http.log')\n",
     "print('Read in {:d} Rows...'.format(len(bro_df)))\n",
     "bro_df.head()"


### PR DESCRIPTION
Just a quick typo fix. The notebook works with the HTTP log but the text referenced the DNS log.