### PR TITLE
Added further options on how to http_user_agents.py

### DIFF
--- a/examples/http_user_agents.py
+++ b/examples/http_user_agents.py
@@ -14,7 +14,9 @@ if __name__ == '__main__':
 
     # Collect args from the command line
     parser = argparse.ArgumentParser()
-    parser.add_argument('-f', '--bro-log', type=str, help='Specify a bro log to run BroLogReader test on')
+    parser.add_argument('-f', '--bro-log', type=str, required=True, help='Specify a bro log to run BroLogReader test on')
+    parser.add_argument('-t', action='store_true', default=False, help='Sets the program to tail a live Bro log')
+    parser.add_argument('-s', action='store_true', default=False, help='Only print the summary of the findings.')
     args, commands = parser.parse_known_args()
 
     # Check for unknown args
@@ -38,15 +40,16 @@ if __name__ == '__main__':
 
         # Run the bro reader on a given log file counting up user agents
         http_agents = Counter()
-        reader = bro_log_reader.BroLogReader(args.bro_log, tail=True)
+        reader = bro_log_reader.BroLogReader(args.bro_log, tail=args.t)
         for count, row in enumerate(reader.readrows()):
             # Track count
             http_agents[row['user_agent']] += 1
 
             # Every hundred rows report agent counts (least common)
-            if count%100==0:
-                print('\n<<<Least Common User Agents>>>')
-                pprint(http_agents.most_common()[:-50:-1])
+            if not args.s:
+                if count%100==0:
+                    print('\n<<<Least Common User Agents>>>')
+                    pprint(http_agents.most_common()[:-50:-1])
 
         # Also report at the end (if there is one)
         print('\nLeast Common User Agents:')


### PR DESCRIPTION
I ran the http_user_agents.py example against one of my rotated http.log files here and realised that it keeps looping through the file and never prints the final findings.

I added two more options to the argparser. 

Firstly, -t which sets the software to tail a live log. By default this is set to False. 

Secondly, -s which sets it not to print the findings every 100 rows and only print the final findings. By default this is set to False.

If you run http_user_agents.py against a rotated out logfile using only the '-s' arguments will, IMHO, give you the best output.

I also added the '-f' option to be required/mandatory.

Hope this is all ok? 