### PR TITLE
Removed superfluous check for number of command line arguments

### DIFF
--- a/examples/anomaly_detection.py
+++ b/examples/anomaly_detection.py
@@ -34,11 +34,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # File may have a tilde in it
     if args.bro_log:
         args.bro_log = os.path.expanduser(args.bro_log)

--- a/examples/anomaly_detection_streaming.py
+++ b/examples/anomaly_detection_streaming.py
@@ -31,11 +31,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # File may have a tilde in it
     if args.bro_log:
         args.bro_log = os.path.expanduser(args.bro_log)

--- a/examples/bro_pprint.py
+++ b/examples/bro_pprint.py
@@ -22,11 +22,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # File may have a tilde in it
     if args.bro_log:
         args.bro_log = os.path.expanduser(args.bro_log)

--- a/examples/bro_to_pandas.py
+++ b/examples/bro_to_pandas.py
@@ -20,11 +20,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # File may have a tilde in it
     if args.bro_log:
         args.bro_log = os.path.expanduser(args.bro_log)

--- a/examples/bro_to_parquet.py
+++ b/examples/bro_to_parquet.py
@@ -21,11 +21,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # File may have a tilde in it
     if args.bro_log and args.parquet_file:
         args.bro_log = os.path.expanduser(args.bro_log)

--- a/examples/bro_to_scikit.py
+++ b/examples/bro_to_scikit.py
@@ -33,11 +33,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # Sanity check that this is a dns log
     if not args.bro_log.endswith('dns.log'):
         print('This example only works with Bro dns.log files..')

--- a/examples/cert_checker.py
+++ b/examples/cert_checker.py
@@ -22,11 +22,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # Sanity check that this is a dns log
     if not args.bro_log.endswith('x509.log'):
         print('This example only works with Bro x509.log files..')

--- a/examples/file_log_vtquery.py
+++ b/examples/file_log_vtquery.py
@@ -22,11 +22,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # Sanity check that this is a file log
     if not args.bro_log.endswith('files.log'):
         print('This example only works with Bro files.log files..')

--- a/examples/http_user_agents.py
+++ b/examples/http_user_agents.py
@@ -24,11 +24,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # Sanity check that this is a http log
     if not args.bro_log.endswith('http.log'):
         print('This example only works with Bro http.log files..')

--- a/examples/risky_dns.py
+++ b/examples/risky_dns.py
@@ -39,11 +39,6 @@ if __name__ == '__main__':
         print('Unrecognized args: %s' % commands)
         sys.exit(1)
 
-    # If no args just call help
-    if len(sys.argv) == 1:
-        parser.print_help()
-        sys.exit(1)
-
     # Sanity check that this is a dns log
     if not args.bro_log.endswith('dns.log'):
         print('This example only works with Bro dns.log files..')


### PR DESCRIPTION
It dawned on me that since I changed the bro_log argument to be positional we no longer need the following check for number of command line arguments:

```
    # If no args just call help
    if len(sys.argv) == 1:
        parser.print_help()
        sys.exit(1)
```
The argparse module handles this itself now.