### PR TITLE
Remove install_requires that are not used by bat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'scipy',
         'pandas',
         'scikit-learn',
-        'pyspark',
         'pyarrow'
     ],
     extras_require={


### PR DESCRIPTION
The requirements list within setup.py should be limited only to packages specifically required by the bat package itself.

Fixes #51