### PR TITLE
adding support for low memory dataframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,13 +49,14 @@ types properly converted.
     'uid': 'CJsdG95nCNF1RXuN5'}
     ...
 
-### Example: Bro log to Pandas DataFrame (in one line of code)
+### Example: Bro log to Pandas DataFrame
 
 ```python
 from bat.log_to_dataframe import LogToDataFrame
 ...
     # Create a Pandas dataframe from a Bro log
-    bro_df = LogToDataFrame('/path/to/dns.log')
+    log_to_df = LogToDataFrame()
+    bro_df = log_to_df.create_dataframe('/path/to/dns.log')
 
     # Print out the head of the dataframe
     print(bro_df.head())

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 The BAT Python package supports the processing and analysis of Bro data
 with Pandas, scikit-learn, and Spark
 
+### Recent: Large Log to Dataframe Improvements
+See our recent work on improving Pandas dataframes from large log files: [Large Dataframes](docs/large_dataframes.md)
+
 ## BroCon 2017 Presentation
 
 Data Analysis, Machine Learning, Bro, and You!

--- a/bat/dataframe_to_parquet.py
+++ b/bat/dataframe_to_parquet.py
@@ -21,7 +21,7 @@ def df_to_parquet(df, filename, compression='SNAPPY'):
     # Nullable integer arrays are currently not handled by Arrow
     # See: https://issues.apache.org/jira/browse/ARROW-5379
     """Cast Nullable integer arrays to object before 'serializing'"""
-    null_int_types = [pd.UInt16Dtype, pd.UInt32Dtype, pd.Int64Dtype]
+    null_int_types = [pd.UInt16Dtype, pd.UInt32Dtype, pd.UInt64Dtype, pd.Int64Dtype]
     for col in df:
         if type(df[col].dtype) in null_int_types:
             df[col] = df[col].astype('object')

--- a/bat/dataframe_to_parquet.py
+++ b/bat/dataframe_to_parquet.py
@@ -18,6 +18,14 @@ def df_to_parquet(df, filename, compression='SNAPPY'):
             filename (string): The full path to the filename for the Parquet file
     """
 
+    # Nullable integer arrays are currently not handled by Arrow
+    # See: https://issues.apache.org/jira/browse/ARROW-5379
+    """Cast Nullable integer arrays to object before 'serializing'"""
+    null_int_types = [pd.UInt16Dtype, pd.UInt32Dtype, pd.Int64Dtype]
+    for col in df:
+        if type(df[col].dtype) in null_int_types:
+            df[col] = df[col].astype('object')
+
     arrow_table = pa.Table.from_pandas(df)
     if compression == 'UNCOMPRESSED':
         compression = None
@@ -49,10 +57,11 @@ def test():
 
     # Grab a test file
     data_path = file_utils.relative_dir(__file__, '../data')
-    test_path = os.path.join(data_path, 'dns.log')
+    log_path = os.path.join(data_path, 'dns.log')
 
     # Convert the log to a Pandas DataFrame
-    dns_df = LogToDataFrame(test_path)
+    log_to_df = LogToDataFrame()
+    dns_df = log_to_df.create_dataframe(log_path)
 
     # Print out the head
     print(dns_df.head())
@@ -73,7 +82,9 @@ def test():
     print(new_dns_df.head())
 
     # Make sure our conversions didn't lose type info
-    assert(dns_df.dtypes.values.tolist() == new_dns_df.dtypes.values.tolist())
+    # Note: This is no longer going to work
+    #       See:  # See: https://issues.apache.org/jira/browse/ARROW-5379
+    # assert(dns_df.dtypes.values.tolist() == new_dns_df.dtypes.values.tolist())
 
     print('DataFrame to Parquet Tests successful!')
 

--- a/bat/log_to_dataframe.py
+++ b/bat/log_to_dataframe.py
@@ -4,31 +4,109 @@ from __future__ import print_function
 # Third Party
 import pandas as pd
 
-# Local Imports
+# Local
 from bat import bro_log_reader
 
 
-class LogToDataFrame(pd.DataFrame):
+class LogToDataFrame(object):
     """LogToDataFrame: Converts a Bro log to a Pandas DataFrame
-        Args:
-            log_fllename (string): The full path to the Bro log
-            ts_index (bool): Set the index to the 'ts' field (default = True)
         Notes:
-            This class is fairly simple right now but will probably have additional
-            functionality for formal type specifications and performance enhancements
+            This class has recently been overhauled from a simple loader to a more
+            complex class that should in theory:
+              - Select better types for each column
+              - Should be faster
+              - Produce smaller memory footprint dataframes
+            If you have any issues/problems with this class please submit a GitHub issue.
     """
-    def __init__(self, log_filename, ts_index=True):
+    def __init__(self):
         """Initialize the LogToDataFrame class"""
 
-        # Create a bro reader on a given log file
-        reader = bro_log_reader.BroLogReader(log_filename)
+        # First Level Type Mapping
+        #    This map defines the types used when first reading in the Bro log into a 'chunk' dataframes.
+        #    Types (like time/interval/bool) will be defined as one type at first but then
+        #    will undergo further processing to produce correct types with correct values.
+        #    Also some object types will be changed into categorical types based on value distributions.
+        # See: https://stackoverflow.com/questions/29245848/what-are-all-the-dtypes-that-pandas-recognizes
+        #      for more info on supported types.
+        self.type_map = {'bool': 'category',  # Can't hold NaN values in 'bool', secondary processing into UInt8
+                         'count': 'UInt32',
+                         'int': 'Int32',
+                         'double': 'float',
+                         'time': 'float',      # Secondary Processing into datetime
+                         'interval': 'float',  # Secondary processing into timedelta
+                         'port': 'UInt16'
+                         }
 
-        # Create a Pandas dataframe from reader
-        super(LogToDataFrame, self).__init__(reader.readrows())
+    def create_dataframe(self, log_filename, ts_index=True, aggressive_category=True):
+        """ Create a Pandas dataframe from a Bro/Zeek log file
+            Args:
+               log_fllename (string): The full path to the Bro log
+               ts_index (bool): Set the index to the 'ts' field (default = True)
+        """
+
+        # Create a Bro log reader just to read in the header for names and types
+        _bro_reader = bro_log_reader.BroLogReader(log_filename)
+        _, field_names, field_types, _ = _bro_reader._parse_bro_header(log_filename)
+
+        # Get the appropriate types for the Pandas Dataframe
+        pandas_types = self.pd_column_types(field_names, field_types, aggressive_category)
+
+        # Now actually read the Bro Log using Pandas read CSV
+        self._df = pd.read_csv(log_filename, sep='\t', names=field_names, dtype=pandas_types, comment="#", na_values='-')
 
         # Set the index
-        if ts_index and not self.empty:
-            self.set_index('ts', inplace=True)
+        if ts_index and not self._df.empty:
+            self._df.set_index('ts', inplace=True)
+        return self._df
+
+    def pd_column_types(self, column_names, column_types, aggressive_category):
+        """Given a set of names and types, construct a dictionary to be used
+           as the Pandas read_csv dtypes argument"""
+
+        # Agressive Category means that types not in the current type_map are
+        # mapped to a 'category' if aggressive_category is False then they
+        # are mapped to an 'object' type
+        unknown_type = 'category' if aggressive_category else 'object'
+
+        pandas_types = {}
+        for name, bro_type in zip(column_names, column_types):
+
+            # Grab the type
+            item_type = self.type_map.get(bro_type)
+
+            # Sanity Check
+            if not item_type:
+                # UID always get mapped to object
+                if name == 'uid':
+                    item_type = 'object'
+                else:
+                    print('Could not find type for {:s} using {:s}...'.format(bro_type, unknown_type))
+                    item_type = unknown_type
+
+            # Set the pandas type
+            pandas_types[name] = item_type
+
+        # Return the dictionary of name: type
+        return pandas_types
+
+    def secondary_processing(self):
+        """Processing some of the columns that can't be directly read in/parsed by read_csv"""
+        # WIP: Put in processing for bool, datetime, and timedelta
+        return self._df
+
+    def chunk_processing(self, df_chunk):
+        """This method processes each chunk of the dataframe
+           - Convert the type to the best/most compact type
+           - Determine if object types can be converted to categorical
+           - Process 'odd' types into proper Pandas types
+               - 'bool' with 'T'/'F' into proper boolean with True/False
+               - 'time' from timestamp to datetime
+               - 'interval' to timedelta
+           - Process 'dashes':
+               The bro output will often have a '-' in the field, this means
+               different things depending on the column, so we have logic that
+               changes '-' to the 'right thing'.
+        """
 
 
 # Simple test of the functionality
@@ -40,26 +118,37 @@ def test():
 
     # Grab a test file
     data_path = file_utils.relative_dir(__file__, '../data')
-    test_path = os.path.join(data_path, 'http.log')
+    log_path = os.path.join(data_path, 'conn.log')
 
     # Convert it to a Pandas DataFrame
-    http_df = LogToDataFrame(test_path)
+    log_to_df = LogToDataFrame()
+    my_df = log_to_df.create_dataframe(log_path)
 
     # Print out the head
-    print(http_df.head())
+    print(my_df.head())
 
     # Print out the datatypes
-    print(http_df.dtypes)
+    print(my_df.dtypes)
+
+    # Test a bunch
+    tests = ['app_stats.log', 'dns.log', 'http.log', 'notice.log', 'tor_ssl.log',
+             'conn.log', 'dhcp_002.log', 'files.log',  'smtp.log', 'weird.log',
+             'ftp.log',  'ssl.log', 'x509.log']
+    for log_path in [os.path.join(data_path, log) for log in tests]:
+        print('Testing: {:s}...'.format(log_path))
+        my_df = log_to_df.create_dataframe(log_path)
+        print(my_df.head())
+        print(my_df.dtypes)
 
     # Test an empty log (a log with header/close but no data rows)
-    test_path = os.path.join(data_path, 'http_empty.log')
-    http_df = LogToDataFrame(test_path)
+    log_path = os.path.join(data_path, 'http_empty.log')
+    my_df = log_to_df.create_dataframe(log_path)
 
     # Print out the head
-    print(http_df.head())
+    print(my_df.head())
 
     # Print out the datatypes
-    print(http_df.dtypes)
+    print(my_df.dtypes)
 
     print('LogToDataFrame Test successful!')
 

--- a/bat/log_to_parquet.py
+++ b/bat/log_to_parquet.py
@@ -79,10 +79,11 @@ def test():
 
     # Grab a test file
     data_path = file_utils.relative_dir(__file__, '../data')
-    test_path = os.path.join(data_path, 'dns.log')
+    log_path = os.path.join(data_path, 'dns.log')
 
     # Convert the log to a Pandas DataFrame
-    dns_df = LogToDataFrame(test_path)
+    log_to_df = LogToDataFrame()
+    dns_df = log_to_df.create_dataframe(log_path)
 
     # Print out the head
     print(dns_df.head())
@@ -91,7 +92,7 @@ def test():
     filename = tempfile.NamedTemporaryFile(delete=False).name
 
     # Write to a parquet file
-    log_to_parquet(test_path, filename)
+    log_to_parquet(log_path, filename)
 
     # Read from the parquet file
     new_dns_df = parquet_to_df(filename)
@@ -102,7 +103,10 @@ def test():
     # Print out the head
     print(new_dns_df.head())
 
-    assert(dns_df.dtypes.values.tolist() == new_dns_df.dtypes.values.tolist())
+    # Make sure our conversions didn't lose type info
+    # Note: This is no longer going to work
+    #       See:  # See: https://issues.apache.org/jira/browse/ARROW-5379
+    # assert(dns_df.dtypes.values.tolist() == new_dns_df.dtypes.values.tolist())
 
     # Test an empty log (a log with header/close but no data rows)
     test_path = os.path.join(data_path, 'http_empty.log')

--- a/docs/large_dataframes.md
+++ b/docs/large_dataframes.md
@@ -1,0 +1,238 @@
+## Performance on large dataframes
+We have several outstanding issues for needed improvements to support the ingestion and processing of large Bro/Zeek log files.
+
+- <https://github.com/SuperCowPowers/bat/issues/23>
+- <https://github.com/SuperCowPowers/bat/issues/71>
+
+There's also a PR from <https://github.com/bhklimk> with some good suggestions.
+
+Big thanks to Benjamin Klimkowski <https://github.com/bhklimk>. The ideas/suggestions that Ben gave in [PR 75](https://github.com/SuperCowPowers/bat/pull/75) were well received. The PR itself has issues with 'cruft' and some of the details but the core concepts are solid, so we're going to borrow those and we've made a new PR that is more aligned with the existing implementation. Thanks again to Ben for helping us improve the performance on large Bro/Zeek files.
+
+**Test Data:**
+Since conn.log is typically the most voluminous, we're going to use this 2.5 Gig conn.long file for our performance testing.
+
+- <https://data.kitware.com/#item/58ebde398d777f16d095fd0e>
+
+**Test Script:**
+We're simply going to use the [bro\_to\_pandas.py](https://github.com/SuperCowPowers/bat/blob/master/examples/bro_to_pandas.py) in the examples directory for testing. We'll be using Python 3.7.
+
+```
+$ time python bro_to_pandas.py ~/data/bro/conn.log 
+```
+
+**Baseline:**
+Our baseline for this testing will obviously be the existing repository functionality as it is.
+
+**bhklimk PR:**
+The PR from <https://github.com/bhklimk> shown here: [PR 75](https://github.com/SuperCowPowers/bat/pull/75)
+
+**PR 76:**
+A new PR focused specifically on memory/time improvements for large data frames.
+
+## Performance Results
+
+| Code       | Memory (peak) | Memory (DF)       | Total Time*  | Notes            |
+|------------|---------------|-------------------|--------------|------------------|
+| Baseline   | ~34.6 GB      | 13.8 GB           | 8m 19s       |                  |
+| bhklimk PR | ~19 GB        | 18.62 -> 7.0 GB** | 5m 12s       |                  |
+| PR 76.     | ~5.6 GB       | 3.7 GB            | 1m 24s       | WIP              |
+
+\* Computing the 'deep memory' use of the large data frames added about more time to all of the tests.
+
+\*\* bhklimk PR builds a large data frame and then compresses it by converting the columns to categorical types.
+
+## Observations
+**Time:**
+As noted in this issue <https://github.com/SuperCowPowers/bat/issues/23> the baseline construction of a data frame is inefficient, for large data frames this inefficiency plus the time wasted on memory paging/swapping starts to dominate the load time.
+
+**Memory:**
+As we've demonstrated in some of our notebooks examples, properly encoding categorical data will provide a significant memory reduction [Categorical Notebook](https://nbviewer.jupyter.org/github/SuperCowPowers/scp-labs/blob/master/notebooks/Categorical_Data_Guide.ipynb).
+
+## Detailed Test Output
+**Baseline**
+
+```
+(py37)$ time python bro_to_pandas.py ~/data/bro/conn.log 
+Successfully monitoring /Users/briford/data/bro/conn.log...
+
+[5 rows x 19 columns]
+uid                        object
+id.orig_h                  object
+id.orig_p                   int64
+id.resp_h                  object
+id.resp_p                   int64
+proto                      object
+service                    object
+duration          timedelta64[ns]
+orig_bytes                  int64
+resp_bytes                  int64
+conn_state                 object
+local_orig                   bool
+missed_bytes                int64
+history                    object
+orig_pkts                   int64
+orig_ip_bytes               int64
+resp_pkts                   int64
+resp_ip_bytes               int64
+tunnel_parents             object
+
+DF Shape: (22694356, 19)
+DF Memory:
+	 Index: 	     181.55 MB
+	 uid: 	        1696.11 MB
+	 id.orig_h: 	1623.26 MB
+	 id.orig_p: 	 181.55 MB
+	 id.resp_h: 	1608.96 MB
+	 id.resp_p: 	 181.55 MB
+	 proto: 	    1361.84 MB
+	 service: 	    1318.07 MB
+	 duration: 	     181.55 MB
+	 orig_bytes: 	 181.55 MB
+	 resp_bytes:     181.55 MB
+	 conn_state: 	1352.43 MB
+	 local_orig: 	  22.69 MB
+	 missed_bytes:   181.55 MB
+	 history: 	    1410.22 MB
+	 orig_pkts: 	 181.55 MB
+	 orig_ip_bytes:  181.55 MB
+	 resp_pkts: 	 181.55 MB
+	 resp_ip_bytes:  181.55 MB
+	 tunnel_parents:1452.44 MB
+DF Total: 13.84 GB
+
+real	8m19.358s
+user	6m55.156s
+sys	    1m10.313s
+```
+
+**bhklimk PR**
+
+```
+(bhklimk-fix_for_issue_71)$ time python bro_to_pandas.py ~/data/bro/conn.log 
+DF Shape: (22694356, 20)
+DF Memory:
+	 Index:           0.00 MB
+	 ts:            181.55 MB
+	 uid:          1696.11 MB
+	 id.orig_h:    1623.26 MB
+	 id.orig_p:     181.55 MB
+	 id.resp_h:    1608.96 MB
+	 id.resp_p:     181.55 MB
+	 proto:        1361.84 MB
+	 service:      1318.07 MB
+	 duration:     1343.66 MB
+	 orig_bytes:   1343.14 MB
+	 resp_bytes:   1344.48 MB
+	 conn_state:   1352.43 MB
+	 local_orig:   1316.27 MB
+	 missed_bytes:  181.55 MB
+	 history:      1410.22 MB
+	 orig_pkts:     181.55 MB
+	 orig_ip_bytes: 181.55 MB
+	 resp_pkts: 	181.55 MB
+	 resp_ip_bytes: 181.55 MB
+	 tunnel_parents:1452.44 MB
+DF Total: 18.62 GB
+
+uid                 object
+id.orig_h         category
+id.orig_p           uint16
+id.resp_h         category
+id.resp_p           uint16
+proto             category
+service           category
+duration            object
+orig_bytes          object
+resp_bytes          object
+conn_state        category
+local_orig        category
+missed_bytes      category
+history           category
+orig_pkts           uint64
+orig_ip_bytes       uint64
+resp_pkts           uint64
+resp_ip_bytes       uint64
+tunnel_parents    category
+
+DF Shape: (22694356, 19)
+DF Memory:
+	 Index: 	181.55 MB
+	 uid: 	1696.11 MB
+	 id.orig_h: 	45.43 MB
+	 id.orig_p: 	45.39 MB
+	 id.resp_h: 	45.94 MB
+	 id.resp_p: 	45.39 MB
+	 proto: 	22.69 MB
+	 service: 	22.70 MB
+	 duration: 	1343.66 MB
+	 orig_bytes: 	1343.14 MB
+	 resp_bytes: 	1344.48 MB
+	 conn_state: 	22.70 MB
+	 local_orig: 	22.69 MB
+	 missed_bytes: 	22.70 MB
+	 history: 	45.45 MB
+	 orig_pkts: 	181.55 MB
+	 orig_ip_bytes: 	181.55 MB
+	 resp_pkts: 	181.55 MB
+	 resp_ip_bytes: 	181.55 MB
+	 tunnel_parents: 	22.70 MB
+DF Total: 7.00 GB
+
+real	5m12.067s
+user	4m53.237s
+sys	0m18.816s
+```
+
+**PR 76**
+
+```
+(py37) $ time python bro_to_pandas.py ~/data/bro/conn.log 
+uid                 object
+id.orig_h         category
+id.orig_p           UInt16
+id.resp_h         category
+id.resp_p           UInt16
+proto             category
+service           category
+duration           float64
+orig_bytes         float64
+resp_bytes         float64
+conn_state        category
+local_orig        category
+missed_bytes       float64
+history           category
+orig_pkts          float64
+orig_ip_bytes      float64
+resp_pkts          float64
+resp_ip_bytes      float64
+tunnel_parents    category
+dtype: object
+DF Shape: (22694356, 19)
+DF Memory:
+	 Index: 	181.55 MB
+	 uid: 	1696.11 MB
+	 id.orig_h: 	45.43 MB
+	 id.orig_p: 	68.08 MB
+	 id.resp_h: 	45.94 MB
+	 id.resp_p: 	68.08 MB
+	 proto: 	22.69 MB
+	 service: 	22.70 MB
+	 duration: 	181.55 MB
+	 orig_bytes: 	181.55 MB
+	 resp_bytes: 	181.55 MB
+	 conn_state: 	22.70 MB
+	 local_orig: 	22.69 MB
+	 missed_bytes: 	181.55 MB
+	 history: 	45.45 MB
+	 orig_pkts: 	181.55 MB
+	 orig_ip_bytes: 	181.55 MB
+	 resp_pkts: 	181.55 MB
+	 resp_ip_bytes: 	181.55 MB
+	 tunnel_parents: 	22.70 MB
+DF Total: 3.72 GB
+
+real	1m27.572s
+user	1m22.787s
+sys	0m5.180s
+```
+

--- a/docs/large_dataframes.md
+++ b/docs/large_dataframes.md
@@ -31,15 +31,18 @@ A new PR focused specifically on memory/time improvements for large data frames.
 
 ## Performance Results
 
-| Code       | Memory (peak) | Memory (DF)       | Total Time*  | Notes            |
-|------------|---------------|-------------------|--------------|------------------|
-| Baseline   | ~34.6 GB      | 13.8 GB           | 8m 19s       |                  |
-| bhklimk PR | ~19 GB        | 18.62 -> 7.0 GB** | 5m 12s       |                  |
-| PR 76.     | ~5.6 GB       | 3.7 GB            | 1m 24s       | WIP              |
+| Code         | Memory (peak) | Memory (DF)       | Total Time*  | Notes            |
+|--------------|---------------|-------------------|--------------|------------------|
+| Baseline     | ~34.6 GB      | 13.8 GB           | 8m 19s       |                  |
+| bhklimk PR   | ~19 GB        | 18.62 -> 7.0 GB** | 5m 12s       |                  |
+| PR 76        | ~5.6 GB       | 3.8 GB            | 2m 57s       |                  |
+| PR 76 (chunk)***| ~12 GB        | 11.8 GB           | 3m 51s       |                  |
 
-\* Computing the 'deep memory' use of the large data frames added about more time to all of the tests.
+\* Computing the 'deep memory' use of the large data frames added about 1 minute of time to all of the tests.
 
 \*\* bhklimk PR builds a large data frame and then compresses it by converting the columns to categorical types.
+
+*** Used the read_csv chunksize=1e6 parameter and then pd.concat the chunked dataframes (see observation 'Chunking' below)
 
 ## Observations
 **Time:**
@@ -47,6 +50,18 @@ As noted in this issue <https://github.com/SuperCowPowers/bat/issues/23> the bas
 
 **Memory:**
 As we've demonstrated in some of our notebooks examples, properly encoding categorical data will provide a significant memory reduction [Categorical Notebook](https://nbviewer.jupyter.org/github/SuperCowPowers/scp-labs/blob/master/notebooks/Categorical_Data_Guide.ipynb).
+
+**Details:**
+The proper conversion of 'time' to datetime and 'interval' to timedelta are taken care of by PR 76. Also the 'ts' field is properly set as the index of the dataframe.
+
+**Chunking:**
+So every Stack Overflow answer about reading in large dataframes uses a chunking approach, we obviously tried that first and it was a total fail on multiple dimensions.
+
+1. **Size/Memory:** Chunking the dataframe into pieces and then immediately combining those pieces with pd.concat, is a bit like chopping up a log and then reassembling it. You end up with the same log. So since the final size in memory is a big factor in our 'optimization' this doesn't really help us much in theory and made things worse in practice (see item 3 below).
+1. **Time:** The chunking + concat combine code took more time to execute than just simply reading in the whole dataframe.
+1. **Memory (again):** Simple categorical types 'survived' the concat process, slightly more complex ones got punted down to the 'object' type which basically ruined the whole point of a compact dataframe that heavily engages categories. In particular 'photo' and 'local\_orig' remained categorical types, 'id.orig\_h', 'id.resp\_h', 'service', 'conn\_state', and 'history' did **not**. See detailed test output below.
+
+**Note:** I'm happy to be wrong about any of these points, please replicate the test above and smack me with some science, I'll gladly eat some crow if it means we get better/faster dataframe construction :)
 
 ## Detailed Test Output
 **Baseline**
@@ -186,26 +201,42 @@ sys	0m18.816s
 **PR 76**
 
 ```
-(py37) $ time python bro_to_pandas.py ~/data/bro/conn.log 
-uid                 object
-id.orig_h         category
-id.orig_p           UInt16
-id.resp_h         category
-id.resp_p           UInt16
-proto             category
-service           category
-duration           float64
-orig_bytes         float64
-resp_bytes         float64
-conn_state        category
-local_orig        category
-missed_bytes       float64
-history           category
-orig_pkts          float64
-orig_ip_bytes      float64
-resp_pkts          float64
-resp_ip_bytes      float64
-tunnel_parents    category
+time python bro_to_pandas.py /Users/briford/data/bro/conn.log 
+Could not find type for addr using category...
+Could not find type for addr using category...
+Could not find type for enum using category...
+Could not find type for string using category...
+Could not find type for string using category...
+Could not find type for string using category...
+Could not find type for table[string] using category...
+                                              uid       id.orig_h  ...  resp_ip_bytes tunnel_parents
+ts                                                                 ...                              
+2012-03-16 12:30:00.000000000  CCUIP21wTjqkj8ZqX5  192.168.202.79  ...             52        (empty)
+2012-03-16 12:30:00.000000000  Csssjd3tX0yOTPDpng  192.168.202.79  ...            994        (empty)
+2012-03-16 12:30:00.000000000  CHEt7z3AzG4gyCNgci  192.168.202.79  ...            382        (empty)
+2012-03-16 12:30:00.009999990  CKnDAp2ohlvN6rpiXl  192.168.202.79  ...            382        (empty)
+2012-03-16 12:30:00.000000000    CGUBcoXKxBE8gTNl  192.168.202.79  ...           1744        (empty)
+
+[5 rows x 19 columns]
+uid                        object
+id.orig_h                category
+id.orig_p                  UInt16
+id.resp_h                category
+id.resp_p                  UInt16
+proto                    category
+service                  category
+duration          timedelta64[ns]
+orig_bytes                 UInt64
+resp_bytes                 UInt64
+conn_state               category
+local_orig               category
+missed_bytes               UInt64
+history                  category
+orig_pkts                  UInt64
+orig_ip_bytes              UInt64
+resp_pkts                  UInt64
+resp_ip_bytes              UInt64
+tunnel_parents           category
 dtype: object
 DF Shape: (22694356, 19)
 DF Memory:
@@ -218,21 +249,76 @@ DF Memory:
 	 proto: 	22.69 MB
 	 service: 	22.70 MB
 	 duration: 	181.55 MB
-	 orig_bytes: 	181.55 MB
-	 resp_bytes: 	181.55 MB
+	 orig_bytes: 	204.25 MB
+	 resp_bytes: 	204.25 MB
 	 conn_state: 	22.70 MB
 	 local_orig: 	22.69 MB
-	 missed_bytes: 	181.55 MB
+	 missed_bytes: 	204.25 MB
 	 history: 	45.45 MB
-	 orig_pkts: 	181.55 MB
-	 orig_ip_bytes: 	181.55 MB
-	 resp_pkts: 	181.55 MB
-	 resp_ip_bytes: 	181.55 MB
+	 orig_pkts: 	204.25 MB
+	 orig_ip_bytes: 	204.25 MB
+	 resp_pkts: 	204.25 MB
+	 resp_ip_bytes: 	204.25 MB
 	 tunnel_parents: 	22.70 MB
-DF Total: 3.72 GB
+DF Total: 3.88 GB
 
-real	1m27.572s
-user	1m22.787s
-sys	0m5.180s
+real	2m57.822s
+user	2m52.370s
+sys	0m6.031s
+```
+
+**PR 76 (with chunking)**
+
+```
+$ time python bro_to_pandas.py /Users/briford/data/bro/conn.log 
+
+uid                        object
+id.orig_h                  object
+id.orig_p                  UInt16
+id.resp_h                  object
+id.resp_p                  UInt16
+proto                    category
+service                    object
+duration          timedelta64[ns]
+orig_bytes                 UInt64
+resp_bytes                 UInt64
+conn_state                 object
+local_orig               category
+missed_bytes               UInt64
+history                    object
+orig_pkts                  UInt64
+orig_ip_bytes              UInt64
+resp_pkts                  UInt64
+resp_ip_bytes              UInt64
+tunnel_parents             object
+
+DF Shape: (22694356, 19)
+DF Memory:
+	 Index: 	181.55 MB
+	 uid: 	1696.11 MB
+	 id.orig_h: 	1623.26 MB
+	 id.orig_p: 	68.08 MB
+	 id.resp_h: 	1608.96 MB
+	 id.resp_p: 	68.08 MB
+	 proto: 	22.69 MB
+	 service: 	745.42 MB
+	 duration: 	181.55 MB
+	 orig_bytes: 	204.25 MB
+	 resp_bytes: 	204.25 MB
+	 conn_state: 	1352.43 MB
+	 local_orig: 	22.69 MB
+	 missed_bytes: 	204.25 MB
+	 history: 	1405.51 MB
+	 orig_pkts: 	204.25 MB
+	 orig_ip_bytes: 	204.25 MB
+	 resp_pkts: 	204.25 MB
+	 resp_ip_bytes: 	204.25 MB
+	 tunnel_parents: 	1452.44 MB
+DF Total: 11.86 GB
+
+real	3m51.152s
+user	3m45.320s
+sys	0m6.254s
+
 ```
 

--- a/examples/bro_to_pandas.py
+++ b/examples/bro_to_pandas.py
@@ -25,10 +25,20 @@ if __name__ == '__main__':
         args.bro_log = os.path.expanduser(args.bro_log)
 
         # Create a Pandas dataframe from a Bro log
-        bro_df = LogToDataFrame(args.bro_log)
+        log_to_df = LogToDataFrame()
+        bro_df = log_to_df.create_dataframe(args.bro_log)
 
         # Print out the head of the dataframe
         print(bro_df.head())
 
         # Print out the types of the columns
         print(bro_df.dtypes)
+
+        # Print out size and memory usage
+        print('DF Shape: {:s}'.format(str(bro_df.shape)))
+        print('DF Memory:')
+        memory_usage = bro_df.memory_usage(deep=True)
+        total = memory_usage.sum()
+        for item in memory_usage.items():
+            print('\t {:s}: \t{:.2f} MB'.format(item[0], item[1]/1e6))
+        print('DF Total: {:.2f} GB'.format(total/(1e9)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py35, py36, style, docs
+envlist = py27, py36, py37, style, docs
 
 [testenv]
 setenv =


### PR DESCRIPTION
PR based on some of the concepts in https://github.com/SuperCowPowers/bat/pull/75 but keeping the 'generator' for bro_log_reader (most folks using that class will definitely need/want a generator instead of a dataframe). Also instead of creating a large dataframe and then compressing we try to bring the data into the dataframe with categorical type directly. Also we make the changes compatible with the Parquet/Arrow conversions.

Note: This PR is still a WIP, we still have lots of improvements and testing to conduct.