### PR TITLE
Make gzip read as much gzip data as possible before moving on instead of causing an exception.

### DIFF
--- a/zat/zeek_multi_log_reader.py
+++ b/zat/zeek_multi_log_reader.py
@@ -40,7 +40,11 @@ class ZeekMultiLogReader(object):
             if self._filepath.endswith('.gz'):
                 tmp = tempfile.NamedTemporaryFile(delete=False)
                 with gzip.open(self._filepath, 'rb') as f_in, open(tmp.name, 'wb') as f_out:
-                    shutil.copyfileobj(f_in, f_out)
+                    try:
+                        for line in f_in:
+                            f_out.write(line)
+                    except Exception as e:
+                        print("Exception in {} : {}".format(self._filepath, e))
 
                 # Set the file path to the new temp file
                 self._filepath = tmp.name


### PR DESCRIPTION
Hi,

Thanks for this great library.  I have several Zeek logs that have some corrupted data at the end when Zeek restarts ungracefully and this change will read as much data as possible from a compressed log before moving on to the next log.

Thanks!