### PR TITLE
Include examples in tox flake8 lint

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,6 @@ deps =
     black
     isort
 commands =
-    flake8 zat/
+    flake8 zat/ examples/
     black --check zat/ examples/ explorations/
     isort --check zat/ examples/ explorations/


### PR DESCRIPTION
## Summary
- include `examples/` in the `tox -e lint` flake8 command
- keep the existing Black and isort lint coverage unchanged

Fixes #117.

## Testing
- `.venv\Scripts\python -m flake8 zat examples`
- `.venv\Scripts\python -m black --check zat examples explorations`
- `.venv\Scripts\python -m isort --check zat examples explorations`
- `git diff --check`