### PR TITLE
Support S3-backed Zeek log inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ Thanks to <https://github.com/Bl4omArchie> for the Dask and Polars Zeek log conv
 ```
 pip install zat
 pip install zat[pyspark] (includes pyspark library)
-pip install zat[all] (include pyarrow, yara-python, and tldextract)
+pip install zat[s3] (includes S3 file access support)
+pip install zat[all] (include pyarrow, yara-python, tldextract, and S3 file access support)
 ```
 
 ### Getting Started

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
 
 [project.optional-dependencies]
 pyspark = ["pyspark"]
-all = ["pyspark", "pyarrow", "yara-python", "tldextract"]
+s3 = ["s3fs"]
+all = ["pyspark", "pyarrow", "yara-python", "tldextract", "s3fs"]
 
 [project.urls]
 Homepage = "https://github.com/SuperCowPowers/zat"

--- a/zat/json_log_to_dataframe.py
+++ b/zat/json_log_to_dataframe.py
@@ -6,6 +6,7 @@ import os
 import pandas as pd
 
 # Local Imports
+from zat.utils.field_info import _is_uri_path
 
 
 class JSONLogToDataFrame(object):
@@ -35,7 +36,7 @@ class JSONLogToDataFrame(object):
            maxrows: Read in a subset of rows for testing/inspecting (default = None)
         """
         # Sanity check the filename
-        if not os.path.isfile(log_filename):
+        if not _is_uri_path(log_filename) and not os.path.isfile(log_filename):
             print(f"Could not find file: {log_filename}")
             return pd.DataFrame()
 
@@ -106,6 +107,18 @@ def test():
     conn_path = os.path.join(data_path, "conn.log")
     my_df = log_to_df.create_dataframe(conn_path, maxrows=3)
     print(my_df.head())
+
+    # Test remote/fsspec paths
+    try:
+        import fsspec
+    except ImportError:
+        print("Remote JSON path test not run, need fsspec...")
+    else:
+        remote_path = "memory://zat/json/conn.log"
+        with open(conn_path, "r") as source_file, fsspec.open(remote_path, "wt") as remote_file:
+            remote_file.write(source_file.read())
+        my_df = log_to_df.create_dataframe(remote_path, maxrows=3)
+        assert len(my_df) == 3
 
     # Test an empty log (a log with header/close but no data rows)
     log_path = os.path.join(data_path, "http_empty.log")

--- a/zat/log_to_dataframe.py
+++ b/zat/log_to_dataframe.py
@@ -170,6 +170,18 @@ def test():
         conn_path, usecols=["id.orig_h", "id.orig_p", "id.resp_h", "id.resp_p", "proto", "orig_bytes", "resp_bytes"]
     )
 
+    # Test remote/fsspec paths
+    try:
+        import fsspec
+    except ImportError:
+        print("Remote Zeek path test not run, need fsspec...")
+    else:
+        remote_path = "memory://zat/logs/conn.log"
+        with open(conn_path, "r") as source_file, fsspec.open(remote_path, "wt") as remote_file:
+            remote_file.write(source_file.read())
+        my_df = log_to_df.create_dataframe(remote_path, usecols=["id.orig_h", "id.resp_h", "proto"])
+        assert not my_df.empty
+
     # Test an empty log (a log with header/close but no data rows)
     log_path = os.path.join(data_path, "http_empty.log")
     my_df = log_to_df.create_dataframe(log_path)

--- a/zat/utils/field_info.py
+++ b/zat/utils/field_info.py
@@ -1,9 +1,79 @@
-from typing import List, Tuple
+from contextlib import contextmanager
+from typing import Iterator, List, TextIO, Tuple
 
-from zat.zeek_log_reader import ZeekLogReader
+
+def _is_uri_path(log_filename: str) -> bool:
+    return "://" in log_filename
+
+
+@contextmanager
+def _open_log_file(log_filename: str) -> Iterator[TextIO]:
+    if not _is_uri_path(log_filename):
+        with open(log_filename, "r") as log_file:
+            yield log_file
+        return
+
+    try:
+        import fsspec
+    except ImportError as exc:
+        raise ImportError(
+            "Reading Zeek logs from URI paths requires fsspec. "
+            "Install zat[s3] for S3 paths, or install the fsspec backend for this URI scheme."
+        ) from exc
+
+    with fsspec.open(log_filename, mode="rt") as log_file:
+        yield log_file
 
 
 def get_field_info(log_filename: str) -> Tuple[List[str], List[str]]:
-    _zeek_reader = ZeekLogReader(log_filename)
-    _, field_names, field_types, _ = _zeek_reader._parse_zeek_header(log_filename)
+    with _open_log_file(log_filename) as log_file:
+        line = log_file.readline()
+        while line and not line.startswith("#fields"):
+            line = log_file.readline()
+
+        if not line:
+            raise ValueError("Could not find Zeek #fields header in {:s}".format(log_filename))
+
+        field_names = line.strip().split("\t")[1:]
+        line = log_file.readline()
+        if not line.startswith("#types"):
+            raise ValueError("Could not find Zeek #types header in {:s}".format(log_filename))
+        field_types = line.strip().split("\t")[1:]
+
     return field_names, field_types
+
+
+def test():
+    import os
+
+    import pytest
+
+    from zat.utils import file_utils
+
+    data_path = file_utils.relative_dir(__file__, "../../data")
+    field_names, field_types = get_field_info(os.path.join(data_path, "conn.log"))
+    assert field_names[:3] == ["ts", "uid", "id.orig_h"]
+    assert field_types[:3] == ["time", "string", "addr"]
+
+    try:
+        import fsspec
+    except ImportError:
+        pytest.skip("pip install fsspec")
+
+    remote_log = "memory://zat/test/conn.log"
+    with fsspec.open(remote_log, "wt") as log_file:
+        log_file.write(
+            "#separator \\x09\n"
+            "#set_separator\t,\n"
+            "#empty_field\t(empty)\n"
+            "#unset_field\t-\n"
+            "#path\tconn\n"
+            "#fields\tts\tuid\tid.orig_h\n"
+            "#types\ttime\tstring\taddr\n"
+            "1.0\tC1\t192.0.2.1\n"
+            "#close\t2026-06-01-00-00-00\n"
+        )
+
+    field_names, field_types = get_field_info(remote_log)
+    assert field_names == ["ts", "uid", "id.orig_h"]
+    assert field_types == ["time", "string", "addr"]


### PR DESCRIPTION
## Summary
- parse Zeek log headers through local files or optional `fsspec` URI paths
- let `LogToDataFrame` and `JSONLogToDataFrame` pass remote paths such as `s3://...` through to Pandas once the matching fsspec backend is installed
- add `zat[s3]` packaging/docs and memory-backed regression coverage for URI input paths

Fixes #141.

## Testing
- `PYTHONPATH=. python -m pytest zat\utils\field_info.py zat\log_to_dataframe.py zat\json_log_to_dataframe.py -q` -> 3 passed
- `python -m black --check zat\utils\field_info.py zat\log_to_dataframe.py zat\json_log_to_dataframe.py`
- `python -m isort --check zat\utils\field_info.py zat\log_to_dataframe.py zat\json_log_to_dataframe.py`
- `python -m flake8 zat\utils\field_info.py zat\log_to_dataframe.py zat\json_log_to_dataframe.py`
- `git diff --check`
- Manual `memory://` LogToDataFrame load returned `(360, 3)`
- `PYTHONPATH=. python -m pytest zat -q` -> 19 passed, 3 skipped, 2 unrelated local Windows failures:
  - `zat/utils/cache.py::test` hit the existing `/tmp/zat_file_storage\my_test_cache` rename collision
  - `zat/utils/signal_utils.py::test` uses `signal.SIGQUIT`, which is not available on Windows