### PR TITLE
Add HDBSCAN to anomaly streaming example

### DIFF
--- a/examples/anomaly_detection_streaming.py
+++ b/examples/anomaly_detection_streaming.py
@@ -12,8 +12,14 @@ import pandas as pd
 from sklearn.cluster import MiniBatchKMeans
 from sklearn.ensemble import IsolationForest
 
+try:
+    import hdbscan
+except ImportError:
+    print("This example needs hdbscan '$ pip install hdbscan'")
+    sys.exit(1)
+
 # Local imports
-from zat import dataframe_cache, dataframe_to_matrix, live_simulator, zeek_log_reader
+from zat import dataframe_cache, dataframe_to_matrix, live_simulator
 
 
 def entropy(string):
@@ -47,10 +53,6 @@ if __name__ == "__main__":
             print("This example only works with Zeek with dns.log files..")
             sys.exit(1)
 
-        # Create a Zeek log reader
-        print("Opening Data File: {:s}".format(args.zeek_log))
-        reader = zeek_log_reader.ZeekLogReader(args.zeek_log, tail=True)
-
         # Create a Zeek IDS log live simulator
         print("Opening Data File: {:s}".format(args.zeek_log))
         reader = live_simulator.LiveSimulator(args.zeek_log, eps=10)  # 10 events per second
@@ -60,6 +62,9 @@ if __name__ == "__main__":
 
         # Streaming Clustering Class
         batch_kmeans = MiniBatchKMeans(n_clusters=5, verbose=True)
+
+        # Density based clustering for each outlier window
+        hdbscan_clusterer = hdbscan.HDBSCAN(min_cluster_size=5, min_samples=2)
 
         # Use the ZeekThon DataframeToMatrix class
         to_matrix = dataframe_to_matrix.DataFrameToMatrix()
@@ -95,20 +100,36 @@ if __name__ == "__main__":
                 # Train/fit and Predict anomalous instances using the Isolation Forest model
                 odd_clf = IsolationForest(contamination=0.2)  # Marking 20% as odd
                 predictions = odd_clf.fit_predict(zeek_matrix)
-                odd_df = zeek_df[predictions == -1]
+                odd_df = zeek_df[predictions == -1].copy()
+                if odd_df.empty:
+                    print("No outliers detected in this window")
+                    continue
 
                 # Now we're going to explore our odd observations with help from KMeans
                 odd_matrix = to_matrix.transform(odd_df[features])
                 batch_kmeans.partial_fit(odd_matrix)
                 clusters = batch_kmeans.predict(odd_matrix).tolist()
-                odd_df["cluster"] = clusters
+                odd_df["kmeans_cluster"] = clusters
+
+                # HDBSCAN gives us a density based view of the same outlier window.
+                # Cluster value -1 means HDBSCAN considers that observation noise.
+                if len(odd_df) >= hdbscan_clusterer.min_cluster_size:
+                    odd_df["hdbscan_cluster"] = hdbscan_clusterer.fit_predict(odd_matrix)
+                else:
+                    odd_df["hdbscan_cluster"] = -1
 
                 # Now group the dataframe by cluster
-                cluster_groups = odd_df.groupby("cluster")
+                cluster_groups = odd_df.groupby("kmeans_cluster")
 
                 # Now print out the details for each cluster
-                show_fields = ["id.orig_h", "id.resp_h", "query"] + features
-                print("<<< Outliers Detected! >>>")
+                show_fields = ["id.orig_h", "id.resp_h", "query"] + features + ["hdbscan_cluster"]
+                print("<<< Outliers Detected: MiniBatchKMeans clusters >>>")
                 for key, group in cluster_groups:
+                    print("\nCluster {:d}: {:d} observations".format(key, len(group)))
+                    print(group[show_fields].head())
+
+                hdbscan_groups = odd_df.groupby("hdbscan_cluster")
+                print("<<< Outliers Detected: HDBSCAN clusters >>>")
+                for key, group in hdbscan_groups:
                     print("\nCluster {:d}: {:d} observations".format(key, len(group)))
                     print(group[show_fields].head())


### PR DESCRIPTION
## Summary
- add HDBSCAN clustering to the streaming anomaly detection example alongside the existing MiniBatchKMeans grouping
- add the explicit hdbscan install message suggested in #103
- remove the overwritten ZeekLogReader setup so the example uses the live simulator path directly

## Tests
- python -m py_compile examples\anomaly_detection_streaming.py
- black --check examples\anomaly_detection_streaming.py
- isort --check-only examples\anomaly_detection_streaming.py
- flake8 examples\anomaly_detection_streaming.py
- git diff --check
- python examples\anomaly_detection_streaming.py data\dns.log -> exits with expected `This example needs hdbscan '$ pip install hdbscan'` message when hdbscan is not installed locally

Fixes #103