### PR TITLE
Add AWS S3 Parquet example

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -61,6 +61,32 @@ ts
 2013-09-15 17:44:28.141795  d31qbv1cthcecs.cloudfront.net  192.168.33.10       1030   4.2.2.3
 2013-09-15 17:44:28.422704                crl.entrust.net  192.168.33.10       1030   4.2.2.3
 ```
+
+### Zeek log to S3 Parquet dataset (examples/zeek\_to\_s3\_parquet.py)
+
+```python
+from zat.log_to_dataframe import LogToDataFrame
+import awswrangler as wr
+...
+    log_to_df = LogToDataFrame()
+    zeek_df = log_to_df.create_dataframe('/path/to/http.log')
+
+    wr.s3.to_parquet(
+        df=zeek_df,
+        path='s3://my-bucket/zat/http/',
+        dataset=True,
+        database='zeek',
+        table='http',
+    )
+```
+
+**Example usage:** Install the optional AWS dependencies with
+`pip install 'zat[aws]'`, configure AWS credentials normally, and write a
+local Zeek log as an S3-backed Parquet dataset.
+
+```
+$ python zeek_to_s3_parquet.py ../data/http.log s3://my-bucket/zat/http/ --database zeek --table http
+```
 ### Filter out DNS Whitelists (examples/pandas\_whitelist.py)
 
 ```python

--- a/examples/zeek_to_s3_parquet.py
+++ b/examples/zeek_to_s3_parquet.py
@@ -1,0 +1,110 @@
+"""Write a Zeek log to an S3 Parquet dataset with AWS SDK for pandas."""
+
+import argparse
+import os
+import sys
+from datetime import timedelta
+
+import pandas as pd
+
+from zat.log_to_dataframe import LogToDataFrame
+
+
+def load_awswrangler():
+    """Import AWS SDK for pandas only when this example is executed."""
+    try:
+        import awswrangler as wr
+    except ImportError:
+        print("Please > pip install 'zat[aws]' or pip install awswrangler")
+        sys.exit(1)
+    return wr
+
+
+def convert_timedelta_to_str(df):
+    """Convert timedelta columns to strings before writing Parquet."""
+    delta_columns = df.select_dtypes(include=["timedelta"])
+    for column in delta_columns:
+        df[column] = df[column].apply(tdelta_value_to_str)
+    return df
+
+
+def tdelta_value_to_str(value):
+    """Return a Zeek-compatible string for null or timedelta values."""
+    if pd.isnull(value):
+        return "-"
+    return str(timedelta(seconds=value.total_seconds()))
+
+
+def create_boto3_session(profile_name):
+    """Create a boto3 session when a named AWS profile is requested."""
+    if not profile_name:
+        return None
+
+    try:
+        import boto3
+    except ImportError:
+        print("Please > pip install boto3")
+        sys.exit(1)
+
+    return boto3.Session(profile_name=profile_name)
+
+
+def parse_args():
+    """Collect command-line arguments for the S3 Parquet example."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("zeek_log", type=str, help="Specify the Zeek log input file")
+    parser.add_argument("s3_path", type=str, help="Specify the S3 dataset path, for example s3://bucket/zat/http/")
+    parser.add_argument("--database", type=str, help="Optional Glue/Athena database name")
+    parser.add_argument("--table", type=str, help="Optional Glue/Athena table name")
+    parser.add_argument("--profile-name", type=str, help="Optional AWS profile name")
+    parser.add_argument("--partition-cols", nargs="*", help="Optional columns to partition by")
+    parser.add_argument(
+        "--mode",
+        choices=["append", "overwrite", "overwrite_partitions"],
+        default="overwrite",
+        help="Dataset write mode",
+    )
+    parser.add_argument("--no-index", action="store_true", help="Do not write the DataFrame index")
+    args, commands = parser.parse_known_args()
+
+    if commands:
+        print("Unrecognized args: %s" % commands)
+        sys.exit(1)
+
+    if bool(args.database) != bool(args.table):
+        parser.error("--database and --table must be supplied together")
+
+    return args
+
+
+if __name__ == "__main__":
+    # Example to write a Zeek log as a partitionable S3 Parquet dataset.
+    args = parse_args()
+    wr = load_awswrangler()
+    boto3_session = create_boto3_session(args.profile_name)
+
+    zeek_log = os.path.expanduser(args.zeek_log)
+    log_to_df = LogToDataFrame()
+    zeek_df = log_to_df.create_dataframe(zeek_log)
+    print("DataFrame Created: {:d} rows...".format(len(zeek_df)))
+
+    # AWS SDK for pandas writes Parquet through pyarrow, so keep the timedelta
+    # normalization used by the local Parquet example.
+    zeek_df = convert_timedelta_to_str(zeek_df.copy())
+
+    result = wr.s3.to_parquet(
+        df=zeek_df,
+        path=args.s3_path,
+        index=not args.no_index,
+        compression="snappy",
+        dataset=True,
+        mode=args.mode,
+        database=args.database,
+        table=args.table,
+        partition_cols=args.partition_cols,
+        sanitize_columns=bool(args.database and args.table),
+        boto3_session=boto3_session,
+    )
+
+    print("Complete: {:s} --> {:s}".format(zeek_log, args.s3_path))
+    print("Files Written: {:d}".format(len(result.get("paths", []))))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ dependencies = [
 
 [project.optional-dependencies]
 pyspark = ["pyspark"]
-all = ["pyspark", "pyarrow", "yara-python", "tldextract"]
+aws = ["awswrangler"]
+all = ["pyspark", "pyarrow", "yara-python", "tldextract", "awswrangler"]
 
 [project.urls]
 Homepage = "https://github.com/SuperCowPowers/zat"


### PR DESCRIPTION
## Summary
- add an AWS SDK for pandas example that converts a Zeek log to a partitionable S3 Parquet dataset
- document the new S3 example in the examples guide
- add an optional ws extra and include wswrangler in the ll extra

Addresses #89.

## Testing
- py -m py_compile examples\\zeek_to_s3_parquet.py`n- py -m flake8 examples\\zeek_to_s3_parquet.py`n- py -m black --check examples\\zeek_to_s3_parquet.py`n- py -m isort --check examples\\zeek_to_s3_parquet.py`n- git diff --cached --check`n
## Local execution note
- I did not run the script against S3 because this environment has no AWS credentials configured and should not perform account actions. The example imports wswrangler lazily and prints the optional install command when it is missing.