### PR TITLE
Update Kafka to Spark streaming pipeline

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@
 - [Zeek to Spark](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Zeek_to_Spark.ipynb)
 - [Spark Clustering](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Spark_Clustering.ipynb)
 - [Zeek to Kafka](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Zeek_to_Kafka.ipynb)
-- [Zeek to Kafka to Spark (need updating)](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Zeek_to_Kafka_to_Spark.ipynb)
+- [Zeek to Kafka to Spark](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Zeek_to_Kafka_to_Spark.ipynb)
 - [Clustering: Picking K (or not)](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Clustering_Picking_K.ipynb)
 - [Anomaly Detection Exploration](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Anomaly_Detection.ipynb)
 - [Risky Domains Stats and Deployment](https://nbviewer.jupyter.org/github/SuperCowPowers/zat/blob/main/notebooks/Risky_Domains.ipynb)

--- a/examples/kafka_spark.py
+++ b/examples/kafka_spark.py
@@ -1,10 +1,11 @@
-"""Read Kafka Streams into Spark, perform simple filtering/aggregation"""
+"""Read Kafka Streams into Spark, perform simple filtering/aggregation."""
 
 import argparse
 import sys
 from time import sleep
 
 try:
+    import pyspark
     from pyspark.sql import SparkSession
     from pyspark.sql.functions import col, from_json, udf
     from pyspark.sql.types import BooleanType, IntegerType, StringType, StructType
@@ -27,50 +28,23 @@ def exit_program():
 
 def compute_domain(query):
     # Pull out the domain
+    if not query:
+        return None
     if query.endswith(".local"):
         return "local"
-    return tldextract.extract(query).registered_domain if query else None
+    return tldextract.extract(query).registered_domain or query
 
 
-if __name__ == "__main__":
-    """Read Kafka Streams into Spark, perform simple filtering/aggregation"""
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--server", type=str, default="localhost:9092", help="Specify the Kafka Server (default: localhost:9092)"
-    )
-    args, commands = parser.parse_known_args()
+def spark_kafka_package(spark_version):
+    """Return the Spark Kafka connector coordinate that matches the PySpark version."""
+    major_version = spark_version.split(".", maxsplit=1)[0]
+    scala_binary_version = {"2": "2.11", "3": "2.12", "4": "2.13"}.get(major_version, "2.12")
+    return "org.apache.spark:spark-sql-kafka-0-10_{:s}:{:s}".format(scala_binary_version, spark_version)
 
-    # Check for unknown args
-    if commands:
-        print("Unrecognized args: %s" % commands)
-        sys.exit(1)
 
-    # Grab the Kafka server
-    kserver = args.server
-
-    # Spin up a local Spark Session (with 4 executors)
-    spark = (
-        SparkSession.builder.master("local[4]")
-        .appName("my_awesome")
-        .config("spark.jars.packages", "org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.4")
-        .getOrCreate()
-    )
-    spark.sparkContext.setLogLevel("ERROR")
-
-    # Optimize the conversion to Spark
-    spark.conf.set("spark.sql.execution.arrow.enable", "true")
-
-    # SUBSCRIBE: Setup connection to Kafka Stream
-    raw_data = (
-        spark.readStream.format("kafka")
-        .option("kafka.bootstrap.servers", kserver)
-        .option("subscribe", "dns")
-        .option("startingOffsets", "earliest")
-        .load()
-    )
-
-    # Define the schema for the DNS message (do this better)
-    dns_schema = (
+def dns_log_schema():
+    """Return a Spark schema for Zeek DNS JSON messages emitted by the Kafka plugin."""
+    return (
         StructType()
         .add("ts", StringType())
         .add("uid", StringType())
@@ -97,21 +71,68 @@ if __name__ == "__main__":
         .add("rejected", BooleanType())
     )
 
-    # ETL: Convert raw data into parsed and proper typed data
-    parsed_data = raw_data.select(from_json(col("value").cast("string"), dns_schema).alias("data")).select("data.*")
 
-    # FILTER: Only get DNS records that have 'query' field filled out
-    filtered_data = parsed_data.filter(parsed_data.query.isNotNull() & (parsed_data.query != ""))
+def build_dns_counts(raw_data):
+    """Parse, filter, enrich, and aggregate a Zeek DNS Kafka stream."""
+    parsed_data = raw_data.select(from_json(col("value").cast("string"), dns_log_schema()).alias("data")).select(
+        "data.*"
+    )
 
-    # FILTER 2: Remove Local/mDNS queries
-    filtered_data = filtered_data.filter(~filtered_data.query.like("%.local"))  # Note: using the '~' negation operator
+    filtered_data = parsed_data.filter(col("query").isNotNull() & (col("query") != "") & ~col("query").like("%.local"))
 
-    # COMPUTE: A new column with the 2nd level domain extracted from the query
     udf_compute_domain = udf(compute_domain, StringType())
     computed_data = filtered_data.withColumn("domain", udf_compute_domain("query"))
+    return computed_data.groupBy("`id.orig_h`", "domain", "qtype_name").count()
 
-    # AGGREGATE: In this case a simple groupby operation
-    group_data = computed_data.groupBy("`id.orig_h`", "domain", "qtype_name").count()
+
+if __name__ == "__main__":
+    """Read Kafka Streams into Spark, perform simple filtering/aggregation"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--server", type=str, default="localhost:9092", help="Specify the Kafka Server (default: localhost:9092)"
+    )
+    parser.add_argument("--topic", type=str, default="dns", help="Specify the Kafka topic to read (default: dns)")
+    parser.add_argument(
+        "--kafka-package",
+        type=str,
+        default=None,
+        help="Override the Spark Kafka package coordinate if your Spark distribution uses a different Scala build",
+    )
+    args, commands = parser.parse_known_args()
+
+    # Check for unknown args
+    if commands:
+        print("Unrecognized args: %s" % commands)
+        sys.exit(1)
+
+    # Grab the Kafka server
+    kserver = args.server
+
+    kafka_package = args.kafka_package or spark_kafka_package(pyspark.__version__)
+
+    # Spin up a local Spark Session (with 4 executors)
+    spark = (
+        SparkSession.builder.master("local[4]")
+        .appName("zeek_streaming_etl")
+        .config("spark.jars.packages", kafka_package)
+        .getOrCreate()
+    )
+    spark.sparkContext.setLogLevel("ERROR")
+
+    # Optimize the conversion to Spark
+    spark.conf.set("spark.sql.execution.arrow.enable", "true")
+
+    # SUBSCRIBE: Setup connection to Kafka Stream
+    raw_data = (
+        spark.readStream.format("kafka")
+        .option("kafka.bootstrap.servers", kserver)
+        .option("subscribe", args.topic)
+        .option("startingOffsets", "earliest")
+        .load()
+    )
+
+    # ETL/FILTER/COMPUTE/AGGREGATE: Build the DNS count streaming pipeline
+    group_data = build_dns_counts(raw_data)
 
     # At any point in the pipeline you can see what you're getting out
     group_data.printSchema()
@@ -122,7 +143,7 @@ if __name__ == "__main__":
     )
 
     # Let the pipeline pull some data
-    print("Pulling pipline...Please wait...")
+    print("Pulling pipeline...Please wait...")
 
     # Create a Pandas Dataframe by querying the in memory table and converting
     # Loop around every 5 seconds to update output

--- a/notebooks/Zeek_to_Kafka_to_Spark.ipynb
+++ b/notebooks/Zeek_to_Kafka_to_Spark.ipynb
@@ -67,15 +67,7 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "PySpark: 2.4.4\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pyspark\n",
     "from pyspark.sql import SparkSession\n",
@@ -108,8 +100,13 @@
    "outputs": [],
    "source": [
     "# Spin up a local Spark Session (with 4 executors)\n",
-    "spark = SparkSession.builder.master('local[4]').appName('my_awesome')\\\n",
-    "        .config('spark.jars.packages', 'org.apache.spark:spark-sql-kafka-0-10_2.11:2.4.4')\\\n",
+    "spark_version = pyspark.__version__\n",
+    "major_version = spark_version.split('.', maxsplit=1)[0]\n",
+    "scala_binary_version = {'2': '2.11', '3': '2.12', '4': '2.13'}.get(major_version, '2.12')\n",
+    "kafka_package = f'org.apache.spark:spark-sql-kafka-0-10_{scala_binary_version}:{spark_version}'\n",
+    "\n",
+    "spark = SparkSession.builder.master('local[4]').appName('zeek_streaming_etl')\\\n",
+    "        .config('spark.jars.packages', kafka_package)\\\n",
     "        .getOrCreate()\n",
     "spark.sparkContext.setLogLevel('ERROR')"
    ]
@@ -119,9 +116,7 @@
    "metadata": {},
    "source": [
     "## Loading the Kafka package\n",
-    "In the Spark builder call above we have added the Kafka package as part of the session creation. There are two important things of note:\n",
-    "1. The version at the end (2.4.4) must match the current Spark version.\n",
-    "1. The latest package is ```spark-sql-kafka-0-10_2.12```, we've had no luck with that version in our local testing, it would crash during the 'readStream' call below so we've reverted to the ```spark-sql-kafka-0-10_2.11``` version."
+    "In the Spark builder call above we add the Kafka package as part of the session creation. The version at the end of the package coordinate must match the PySpark version installed in the notebook environment. The Scala binary suffix also needs to match the Spark distribution: Spark 2.x commonly uses `_2.11`, Spark 3.x commonly uses `_2.12`, and Spark 4.x commonly uses `_2.13`. If your local Spark build uses a different Scala binary version, set `kafka_package` explicitly before creating the session."
    ]
   },
   {
@@ -211,7 +206,7 @@
     "  .select('data.*')\n",
     "\n",
     "# FILTER: Only get DNS records that have 'query' field filled out\n",
-    "filtered_data = parsed_data.filter(parsed_data.query.isNotNull() & (parsed_data.query!='')==True)\n",
+    "filtered_data = parsed_data.filter(parsed_data.query.isNotNull() & (parsed_data.query != ''))\n",
     "\n",
     "# FILTER 2: Remove Local/mDNS queries\n",
     "filtered_data = filtered_data.filter(~filtered_data.query.like('%.local'))  # Note: using the '~' negation operator"
@@ -228,9 +223,11 @@
     "\n",
     "def compute_domain(query):\n",
     "    # Pull out the domain\n",
+    "    if not query:\n",
+    "        return None\n",
     "    if query.endswith('.local'):\n",
     "        return 'local'\n",
-    "    return tldextract.extract(query).registered_domain if query else None"
+    "    return tldextract.extract(query).registered_domain or query"
    ]
   },
   {
@@ -608,7 +605,7 @@
     "<img align=\"right\" style=\"padding:20px\" src=\"images/SCP_med.png\" width=\"180\">\n",
     "\n",
     "## Wrap Up\n",
-    "Well that's it for this notebook, we know this ended before we got to the **exciting** part of the streaming data pipeline. For this notebook we showed everything in the pipeline up to aggregation. In future notebooks we'll dive into the deep end of our pipeline and cover the data analysis and machine learning aspects of Spark.\n",
+    "Well that's it for this notebook. We covered the Phase 2 streaming path from Zeek to Kafka to Spark, including JSON parsing, ETL, filtering, domain extraction, aggregation, and a memory sink for inspecting the live result. Future notebooks can build on this foundation for deeper Spark SQL, streaming analytics, and machine learning workflows.\n",
     "\n",
     "If you liked this notebook please visit the [zat](https://github.com/SuperCowPowers/zat) project for more notebooks and examples.\n",
     "\n",


### PR DESCRIPTION
## Summary
- derive the Spark Kafka connector coordinate from the installed PySpark version in the Phase 2 notebook and example
- make the Kafka/Spark example's DNS ETL, filtering, domain enrichment, and aggregation steps reusable
- refresh the Phase 2 notebook wording and documentation index now that the notebook covers the ETL/filtering/Spark path

Fixes #102

## Testing
- py -m py_compile examples\\kafka_spark.py
- py -m black --check examples\\kafka_spark.py
- py -m isort --check-only examples\\kafka_spark.py
- parsed notebooks\\Zeek_to_Kafka_to_Spark.ipynb as JSON
- git diff --check

Note: PySpark is not installed in this local environment, so I could not run the live Kafka/Spark stream end to end.